### PR TITLE
fix: the LinkPreview component url does not redirect to the correct url (#42)

### DIFF
--- a/src/components/feat/LinkInfo/LinkInfo.tsx
+++ b/src/components/feat/LinkInfo/LinkInfo.tsx
@@ -71,7 +71,7 @@ export const LinkInfo = forwardRef<HTMLDivElement, LinkInfoProps>(
                                     <Tooltip>
                                         <TooltipTrigger asChild>
                                             <a
-                                                href="/"
+                                                href={props.data.realurl}
                                                 className="text-blue-500 decoration-solid font-semibold text-xs whitespace-nowrap"
                                                 target="_blank"
                                             >


### PR DESCRIPTION
clsoe #42
